### PR TITLE
feat(mocha): add blueprince-helper app

### DIFF
--- a/mocha/apps/blueprince-helper/app.yaml
+++ b/mocha/apps/blueprince-helper/app.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/briangtn/blue-prince-note-helper.git
-    targetRevision: v1.0.0
+    targetRevision: main
     path: chart
     helm:
       values: |

--- a/mocha/apps/blueprince-helper/app.yaml
+++ b/mocha/apps/blueprince-helper/app.yaml
@@ -29,9 +29,17 @@ spec:
             - secretName: blueprince-helper-tls
               hosts:
                 - "blueprince.lucca.bar"
+        auth:
+          roUser: viewer
+          rwUser: admin
         persistence:
           enabled: true
           size: 1Gi
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      jsonPointers:
+        - /data
   destination:
     server: https://kubernetes.default.svc
     namespace: blueprince-helper

--- a/mocha/apps/blueprince-helper/app.yaml
+++ b/mocha/apps/blueprince-helper/app.yaml
@@ -7,14 +7,14 @@ spec:
   project: default
   source:
     repoURL: https://github.com/briangtn/blue-prince-note-helper.git
-    targetRevision: HEAD
+    targetRevision: v1.0.0
     path: chart
     helm:
       values: |
         image:
           repository: ghcr.io/briangtn/blue-prince-note-helper
-          tag: latest
-          pullPolicy: Always
+          tag: v1.0.0
+          pullPolicy: IfNotPresent
         ingress:
           enabled: true
           className: traefik

--- a/mocha/apps/blueprince-helper/app.yaml
+++ b/mocha/apps/blueprince-helper/app.yaml
@@ -28,7 +28,7 @@ spec:
           tls:
             - secretName: blueprince-helper-tls
               hosts:
-                - "blueprince.<path:kv/cluster#domain>"
+                - "blueprince.lucca.bar"
         persistence:
           enabled: true
           size: 1Gi

--- a/mocha/apps/blueprince-helper/app.yaml
+++ b/mocha/apps/blueprince-helper/app.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: blueprince-helper
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/briangtn/blue-prince-note-helper.git
+    targetRevision: HEAD
+    path: chart
+    helm:
+      values: |
+        image:
+          repository: ghcr.io/briangtn/blue-prince-note-helper
+          tag: latest
+          pullPolicy: Always
+        ingress:
+          enabled: true
+          className: traefik
+          annotations:
+            cert-manager.io/cluster-issuer: cloudflare
+          hosts:
+            - host: "blueprince.<path:kv/cluster#domain>"
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+          tls:
+            - secretName: blueprince-helper-tls
+              hosts:
+                - "blueprince.<path:kv/cluster#domain>"
+        persistence:
+          enabled: true
+          size: 1Gi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: blueprince-helper
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/mocha/apps/blueprince-helper/kustomization.yaml
+++ b/mocha/apps/blueprince-helper/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml


### PR DESCRIPTION
## Summary
- Add Blue Prince Helper deployment to mocha cluster
- ArgoCD Application pointing to Helm chart in `briangtn/blue-prince-note-helper` git repo
- Traefik ingress with TLS via cert-manager, persistent SQLite storage (1Gi PVC)

## Test plan
- [ ] Verify ArgoCD discovers the new app via the `mocha-apps` ApplicationSet
- [ ] Confirm the Helm chart renders correctly (`argocd app diff`)
- [ ] Check pod starts and passes health probes on `/api/rooms/types`
- [ ] Validate ingress and TLS certificate provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)