### PR TITLE
fix(mocha/argocd): restore brian login and SSO app visibility

### DIFF
--- a/mocha/system/argocd-config/argocd-cm.yaml
+++ b/mocha/system/argocd-config/argocd-cm.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  admin.enabled: "true"
+  application.instanceLabelKey: argocd.argoproj.io/instance
+  exec.enabled: "false"
+  server.rbac.log.enforce.enable: "false"
+  statusbadge.enabled: "false"
+  timeout.hard.reconciliation: 0s
+  timeout.reconciliation: 180s
+  url: https://argocd.mocha.thoughtless.eu
+  accounts.brian: apiKey, login
+  dex.config: |
+    connectors:
+    - config:
+        issuer: https://oidc.home.une-tasse-de.cafe/application/o/argocd-mocha/
+        clientID: 0ErFEH07XOcuRf6uNC5dEwcHSIC0b2WfMK0fH2M6
+        clientSecret: $dex.authentik.clientSecret
+        insecureEnableGroups: true
+        scopes:
+          - openid
+          - profile
+          - email
+          - groups
+      name: authentik
+      type: oidc
+      id: authentik
+  resource.exclusions: |
+    - apiGroups:
+      - cilium.io
+      kinds:
+      - CiliumIdentity
+      clusters:
+      - "*"
+  resource.customizations.ignoreResourceUpdates.all: |
+    jsonPointers:
+      - /status
+  resource.customizations.ignoreResourceUpdates.ConfigMap: |
+    jqPathExpressions:
+      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
+      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
+  resource.customizations.ignoreResourceUpdates.Endpoints: |
+    jsonPointers:
+      - /metadata
+      - /subsets
+  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
+    jqPathExpressions:
+      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
+      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
+      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
+  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
+    jqPathExpressions:
+      - '.metadata.annotations."notified.notifications.argoproj.io"'
+      - '.metadata.annotations."argocd.argoproj.io/refresh"'
+      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
+      - '.operation'
+  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
+    jqPathExpressions:
+      - '.metadata.annotations."notified.notifications.argoproj.io"'
+  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+    jqPathExpressions:
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
+  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
+    jsonPointers:
+      - /metadata
+      - /endpoints
+      - /ports

--- a/mocha/system/argocd-config/argocd-rbac-cm.yaml
+++ b/mocha/system/argocd-config/argocd-rbac-cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  policy.default: ""
+  policy.matchMode: glob
+  scopes: '[groups]'
+  policy.csv: |
+    g, authentik Admins, role:admin
+    g, brian, role:admin

--- a/mocha/system/argocd-config/kustomization.yaml
+++ b/mocha/system/argocd-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - argocd-cm.yaml
+  - argocd-rbac-cm.yaml


### PR DESCRIPTION
## Contexte

Sur mocha, plus moyen de se connecter avec le compte local `brian`, et en SSO aucune application n'était visible.

## Cause racine

L'ArgoCD de mocha est installé via Helm mais **n'est géré par aucune release Helm ni Application** (l'app `common` ne synchronise que `common/cert-manager.yaml`, non récursif). Sa config d'auth n'était donc pas versionnée. Un re-apply Helm a réinitialisé `argocd-cm` et `argocd-rbac-cm` :

- `accounts.brian` a disparu de `argocd-cm` → login refusé (le secret bcrypt était intact et correspond bien au mot de passe attendu).
- `argocd-rbac-cm` sans `policy.csv` → utilisateurs SSO sans aucun droit → aucune app.
- Le connecteur dex ne demandait pas le scope `groups` → tokens SSO sans claim `groups`.

## Correctif

Nouveau dossier `mocha/system/argocd-config/`, repris automatiquement par l'ApplicationSet `mocha-system` (→ app `sys-argocd-config`) :

- `argocd-cm` : contenu live complet reproduit (dex/url/customizations préservés) + `accounts.brian: apiKey, login` + scope `groups` ajouté au connecteur authentik.
- `argocd-rbac-cm` : `policy.csv` accordant `role:admin` au groupe `authentik Admins` **et** au compte local `brian`.

## Effet au merge

- ArgoCD prend possession de `argocd-cm`/`argocd-rbac-cm` (comportement voulu).
- `brian` peut de nouveau se connecter et voit toutes les apps.
- Les membres du groupe `authentik Admins` voient les apps en SSO.

https://claude.ai/code/session_01HLFiSKoJzAg3JMyvABVPJz