### PR TITLE
fix(turing): kubelet image GC to prevent Ceph MON_DISK_LOW

### DIFF
--- a/turing/patches/kubelet-imagegc.yml
+++ b/turing/patches/kubelet-imagegc.yml
@@ -1,0 +1,6 @@
+machine:
+  kubelet:
+    extraConfig:
+      imageMaximumGCAge: 72h
+      imageGCHighThresholdPercent: 75
+      imageGCLowThresholdPercent: 60

--- a/turing/template.yaml
+++ b/turing/template.yaml
@@ -21,6 +21,8 @@ patches:
     file: patches/extraManifests.yml
   - name: metric-server
     file: patches/metrics-server.yml
+  - name: kubelet-imagegc
+    file: patches/kubelet-imagegc.yml
 ---
 kind: ControlPlane
 labels:


### PR DESCRIPTION
## Contexte

Rook-Ceph sur turing en `HEALTH_WARN` : `MON_DISK_LOW: mon b is low on available space (30% avail)`.

## Diagnostic

Santé Ceph réelle bonne (PG `active+clean`, 1,8 TiB libres, quorum OK). Le WARN vient du **disque système Talos** hébergeant `mon.b` (`talos-27s-xrh`, `dataDirHostPath: /var/lib/rook`) : disque de 26 GiB (partition unique `nodefs`/`imagefs`) rempli à ~69 %, dont **16,9 GiB d'images conteneurs**.

Le kubelet ne déclenche son GC d'images qu'à `imageGCHighThresholdPercent: 85` — jamais atteint sur ce petit disque — donc les anciennes versions d'images (accumulées au fil des upgrades) ne sont jamais purgées.

## Correctif

Nouveau patch Talos `turing/patches/kubelet-imagegc.yml` (branché dans `template.yaml`) :
- `imageMaximumGCAge: 72h` — le kubelet purge les images inutilisées de plus de 72 h, **indépendamment** de la pression disque (levier principal).
- `imageGCHighThresholdPercent: 75` / `imageGCLowThresholdPercent: 60` — filet de sécurité secondaire.

## Application

À appliquer via `omnictl cluster template sync -f turing/template.yaml`. Redémarre le kubelet des nodes (pas de reboot).

## Note

Un prune ponctuel des images sur `talos-27s-xrh` est fait en parallèle pour repasser `HEALTH_OK` immédiatement ; ce patch évite la récidive.

https://claude.ai/code/session_01HLFiSKoJzAg3JMyvABVPJz