### PR TITLE
fix(turing): lower kubelet imageGC threshold to 65% to clear MON_DISK_LOW now

### DIFF
--- a/turing/patches/kubelet-imagegc.yml
+++ b/turing/patches/kubelet-imagegc.yml
@@ -2,5 +2,5 @@ machine:
   kubelet:
     extraConfig:
       imageMaximumGCAge: 72h
-      imageGCHighThresholdPercent: 75
+      imageGCHighThresholdPercent: 65
       imageGCLowThresholdPercent: 60


### PR DESCRIPTION
## Suite de #376

#376 a ajouté `imageMaximumGCAge: 72h`, mais ce compteur **se réinitialise à chaque redémarrage du kubelet** : le GC par âge ne purgera donc les vieilles images que 72 h après le changement de config, sans résoudre le `HEALTH_WARN` actuel. Et le GC par seuil ne se déclenchait pas non plus (disque à ~70 %, sous le seuil de 75 %).

## Correctif

Abaisse `imageGCHighThresholdPercent` de 75 → **65**. Le kubelet lance alors un GC par seuil **immédiatement** (70 % > 65 %), récupère les ~3,6 GiB d'images inutilisées, et maintient le disque système Talos sous 65 % → le mon Ceph retrouve >30 % de libre et `HEALTH_WARN` disparaît. `imageMaximumGCAge` reste comme filet de sécurité long terme.

## Application

Auto-appliqué par la CI `Omni Template Sync` au merge sur `main`.

https://claude.ai/code/session_01HLFiSKoJzAg3JMyvABVPJz