### PR TITLE
test: verify pr-gitops-grafana-annotation webhook (round 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,4 +195,4 @@ users:
 ```
 </details>
 
-<!-- test: verifying pr-gitops-grafana-annotation webhook, safe to remove -->
+<!-- test: verifying pr-gitops-grafana-annotation webhook (round 2), safe to remove -->


### PR DESCRIPTION
Second trivial change to confirm the Grafana annotation now fires after the case-sensitivity fix.