### PR TITLE
feat(mocha): add languagetool app

### DIFF
--- a/mocha/apps/languagetool/app.yaml
+++ b/mocha/apps/languagetool/app.yaml
@@ -1,0 +1,67 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: languagetool
+  namespace: argocd
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: languagetool
+  source:
+    repoURL: https://rubxkube.github.io/charts
+    chart: languagetool
+    targetRevision: 0.1.0
+    helm:
+      values: |
+        common:
+          ingress:
+            enabled: true
+            hostName: languagetool.mocha.thoughtless.eu
+            ingressClassName: traefik
+            tls:
+              enabled: true
+              secretName: languagetool-tls
+            annotations:
+              cert-manager.io/cluster-issuer: cloudflare
+              # IP allow-list is enforced by the Traefik Middleware defined in
+              # extraResources below. The reference format for the kubernetescrd
+              # provider is <middleware-namespace>-<middleware-name>@kubernetescrd.
+              traefik.ingress.kubernetes.io/router.middlewares: languagetool-allowlist@kubernetescrd
+
+          persistence:
+            enabled: true
+            volumes:
+              - name: fasttext
+                storageClassName: openebs-lvmpv
+                size: 1Gi
+                pvcClaim: ""
+                containerMount: /fasttext
+              - name: ngrams
+                storageClassName: openebs-lvmpv
+                size: 5Gi
+                pvcClaim: ""
+                containerMount: /ngrams
+
+          extraResources:
+            # Restricts languagetool.mocha.thoughtless.eu to the CIDRs listed
+            # below. Attached to the Ingress through the router.middlewares
+            # annotation above. Traefik v3 uses ipAllowList (renamed from the
+            # v2 ipWhiteList). websecure already trusts the OVH LB via
+            # forwardedHeaders.trustedIPs, so the real client IP is evaluated
+            # here without extra ipStrategy config.
+            - apiVersion: traefik.io/v1alpha1
+              kind: Middleware
+              metadata:
+                name: allowlist
+              spec:
+                ipAllowList:
+                  sourceRange:
+                    # Allowed external clients
+                    - 104.30.161.148/32
+                    - 82.64.54.199/32

--- a/mocha/apps/languagetool/kustomization.yaml
+++ b/mocha/apps/languagetool/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml


### PR DESCRIPTION
## What

Deploys **LanguageTool** on the **Mocha** cluster via ArgoCD.

The Application pulls the `languagetool` chart (v0.1.0) from the RubxKube Helm repo (`https://rubxkube.github.io/charts`), following the exact pattern of the existing `rmfakecloud` app (external chart + values nested under `common:`).

## Details

- **Ingress**: standard Traefik `Ingress` (not `IngressRoute`), host `languagetool.mocha.thoughtless.eu`, TLS via cert-manager (`cloudflare` cluster-issuer).
- **IP allow-list**: enforced by a Traefik v3 `ipAllowList` Middleware, attached to the Ingress through the `traefik.ingress.kubernetes.io/router.middlewares` annotation. Allowed sources:
  - `104.30.161.148/32`
  - `82.64.54.199/32`
- **Client IP correctness**: `websecure` already trusts the OVH LB via `forwardedHeaders.trustedIPs`, so the real client IP is evaluated by the middleware (no extra `ipStrategy` needed).
- **Persistence**: two `openebs-lvmpv` PVCs — `/fasttext` (1Gi) and `/ngrams` (5Gi).

## ⚠️ Blocker before this can sync

The `languagetool` chart is **not yet published** in the Helm index. The `Release Charts` workflow on `RubxKube/charts` currently **fails** — not because of this chart (`languagetool-0.1.0.tgz` packages fine) but because of the `searxng` chart (`Error: no repository definition for https://valkey.io/valkey-helm`). chart-releaser processes charts serially and exits on that error, so nothing gets published.

**`targetRevision: 0.1.0` will not resolve until that release is fixed and `languagetool` lands in the index.** This PR is ready to merge/sync as soon as the chart is published.