### PR TITLE
feat(mocha): GitOps-managed KubeVirt+Talos guest clusters

### DIFF
--- a/mocha/bootstrap/as-clusters.yml
+++ b/mocha/bootstrap/as-clusters.yml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mocha-guest-clusters
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/qjoly/gitops.git
+        revision: HEAD
+        files:
+          - path: mocha/clusters/values/*.yaml
+  template:
+    metadata:
+      name: "cluster-{{ .talosCluster.name }}"
+    spec:
+      project: "default"
+      sources:
+        - repoURL: https://github.com/qjoly/kubevirt-capi-easy.git
+          targetRevision: main
+          path: charts/kubevirt-talos
+          helm:
+            valueFiles:
+              - $values/mocha/clusters/values/{{ .path.filename }}
+        - repoURL: https://github.com/qjoly/gitops.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{ .talosCluster.name }}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/mocha/clusters/README.md
+++ b/mocha/clusters/README.md
@@ -51,15 +51,25 @@ mise run talos-poc:kubeconfig   # see ../../mise.toml (parameterised by env)
 
 - CAPI providers: `kubevirt` (infra), `talos` (control-plane + bootstrap),
   `helm` (addon), `in-cluster` (ipam).
-- KubeVirt + CDI, a `longhorn` StorageClass, and the `talos`
+- KubeVirt + CDI, the `openebs-lvmpv` StorageClass (the only one on `mocha`;
+  `longhorn` is not installed), and the `talos`
   `VirtualMachineClusterPreference` (`kubevirt-capi-easy/talosVMCP.yaml`).
+  `openebs-lvmpv`'s CSI `fsGroupPolicy` is `ReadWriteOnceWithFSType`, so the boot
+  DataVolume uses `rootVolumeMode: Filesystem` — a raw `Block` volume makes the
+  non-root CDI importer fail with `cannot open /dev/cdi-block-volume: Permission
+  denied`.
 
 ## Adopting an existing, hand-applied cluster
 
-`talos-poc` was first created manually. Before letting the ApplicationSet
-auto-sync an already-running cluster, review the Argo CD diff: resource names
-carry the `talosCode` suffix, so a mismatch (e.g. `t195` vs `t1137`) makes CAPI
-roll new machine templates. These values pin Talos `v1.13.7` (`t1137`), so
-syncing a cluster still on an older Talos build will roll its VMs onto the new
-image — intended here, but do it deliberately. Either set
-`talosCode`/`talosVersion` to match the live cluster or recreate it from scratch.
+`talos-poc` was first created manually on Talos `v1.9.5`. That cluster has since
+been deleted and re-created from these exact values on Talos `v1.13.7` (`t1137`,
+k8s `v1.36.2`), verified booting to two `Ready` nodes with Cilium. It currently
+runs as a hand-applied cluster (the ApplicationSet is not applied yet), so
+adopting it under Argo CD should show no diff.
+
+More generally, before letting the ApplicationSet auto-sync an already-running
+cluster, review the Argo CD diff: resource names carry the `talosCode` suffix, so
+a mismatch (e.g. `t195` vs `t1137`) makes CAPI roll new machine templates.
+Syncing a cluster still on an older Talos build will roll its VMs onto the new
+image — do it deliberately. Either set `talosCode`/`talosVersion` to match the
+live cluster or recreate it from scratch.

--- a/mocha/clusters/README.md
+++ b/mocha/clusters/README.md
@@ -19,7 +19,7 @@ The chart doing the work lives in
      namespace: dev-quentin
    talosCluster:
      name: dev-quentin
-     talosImageURL: https://factory.talos.dev/image/<hash>/v1.9.5/openstack-amd64.raw.xz
+     talosImageURL: https://factory.talos.dev/image/<hash>/v1.13.7/openstack-amd64.raw.xz
      workerMachineCount: 2
    ```
 
@@ -58,6 +58,8 @@ mise run talos-poc:kubeconfig   # see ../../mise.toml (parameterised by env)
 
 `talos-poc` was first created manually. Before letting the ApplicationSet
 auto-sync an already-running cluster, review the Argo CD diff: resource names
-carry the `talosCode` suffix, so a mismatch (e.g. `t18` vs `t195`) makes CAPI
-roll new machine templates. Either set `talosCode` to match the live cluster
-or recreate it from scratch.
+carry the `talosCode` suffix, so a mismatch (e.g. `t195` vs `t1137`) makes CAPI
+roll new machine templates. These values pin Talos `v1.13.7` (`t1137`), so
+syncing a cluster still on an older Talos build will roll its VMs onto the new
+image — intended here, but do it deliberately. Either set
+`talosCode`/`talosVersion` to match the live cluster or recreate it from scratch.

--- a/mocha/clusters/README.md
+++ b/mocha/clusters/README.md
@@ -1,0 +1,63 @@
+# Guest clusters (KubeVirt + Talos)
+
+GitOps-managed [Cluster API](https://cluster-api.sigs.k8s.io/) guest clusters
+running as KubeVirt VMs on top of `mocha`. Each cluster is a plain Talos +
+Cilium Kubernetes cluster.
+
+The chart doing the work lives in
+[`qjoly/kubevirt-capi-easy`](https://github.com/qjoly/kubevirt-capi-easy)
+(`charts/kubevirt-talos`). Here we only keep the per-cluster values.
+
+## Create a cluster
+
+1. Drop a file in [`values/`](./values/) — one file per cluster. The name of
+   `talosCluster.name` becomes both the cluster name and its namespace.
+
+   ```yaml
+   # values/dev-quentin.yaml
+   global:
+     namespace: dev-quentin
+   talosCluster:
+     name: dev-quentin
+     talosImageURL: https://factory.talos.dev/image/<hash>/v1.9.5/openstack-amd64.raw.xz
+     workerMachineCount: 2
+   ```
+
+   Everything not set falls back to the chart defaults
+   (`charts/kubevirt-talos/values.yaml`).
+
+2. Commit. The `mocha-guest-clusters` ApplicationSet
+   ([`../bootstrap/as-clusters.yml`](../bootstrap/as-clusters.yml)) picks the
+   file up and creates an Argo CD `Application` named `cluster-<name>`.
+
+## Destroy a cluster
+
+Delete its file and commit. Argo CD prunes the `Application`, which deletes the
+`Cluster` object and lets CAPI tear the VMs down.
+
+## Run several
+
+Add several files. The ApplicationSet fans out, one `Application` per file.
+Pod/Service CIDRs live *inside* each guest's VMs, so they can safely be
+identical across clusters — no need to keep them disjoint.
+
+## Get the kubeconfig
+
+```bash
+mise run talos-poc:kubeconfig   # see ../../mise.toml (parameterised by env)
+```
+
+## Prerequisites (management plane, already on `mocha`)
+
+- CAPI providers: `kubevirt` (infra), `talos` (control-plane + bootstrap),
+  `helm` (addon), `in-cluster` (ipam).
+- KubeVirt + CDI, a `longhorn` StorageClass, and the `talos`
+  `VirtualMachineClusterPreference` (`kubevirt-capi-easy/talosVMCP.yaml`).
+
+## Adopting an existing, hand-applied cluster
+
+`talos-poc` was first created manually. Before letting the ApplicationSet
+auto-sync an already-running cluster, review the Argo CD diff: resource names
+carry the `talosCode` suffix, so a mismatch (e.g. `t18` vs `t195`) makes CAPI
+roll new machine templates. Either set `talosCode` to match the live cluster
+or recreate it from scratch.

--- a/mocha/clusters/values/talos-poc.yaml
+++ b/mocha/clusters/values/talos-poc.yaml
@@ -5,7 +5,7 @@ global:
   namespace: talos-poc
 talosCluster:
   name: talos-poc
-  kubernetesVersion: v1.32.1
+  kubernetesVersion: v1.36.2
   controlPlaneMachineCount: 1
   workerMachineCount: 1
   podCIDR: 10.243.0.0/16
@@ -14,9 +14,9 @@ talosCluster:
   instancePreference: talos
   rootVolumeSize: 10Gi
   storageClassName: longhorn
-  talosImageURL: https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.9.5/openstack-amd64.raw.xz
-  talosVersion: v1.9.5
-  talosCode: t195
+  talosImageURL: https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.13.7/openstack-amd64.raw.xz
+  talosVersion: v1.13.7
+  talosCode: t1137
   controlPlaneServiceType: NodePort
   cilium:
     enabled: true

--- a/mocha/clusters/values/talos-poc.yaml
+++ b/mocha/clusters/values/talos-poc.yaml
@@ -13,7 +13,11 @@ talosCluster:
   instanceType: o1.xlarge
   instancePreference: talos
   rootVolumeSize: 10Gi
-  storageClassName: longhorn
+  # mocha only has openebs-lvmpv; longhorn is not installed. Its CSI fsGroupPolicy
+  # is ReadWriteOnceWithFSType, so the boot DataVolume must be Filesystem, else the
+  # CDI importer fails with "cannot open /dev/cdi-block-volume: Permission denied".
+  storageClassName: openebs-lvmpv
+  rootVolumeMode: Filesystem
   talosImageURL: https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.13.7/openstack-amd64.raw.xz
   talosVersion: v1.13.7
   talosCode: t1137

--- a/mocha/clusters/values/talos-poc.yaml
+++ b/mocha/clusters/values/talos-poc.yaml
@@ -1,0 +1,22 @@
+---
+# One file = one guest cluster. Copy it, rename it, commit.
+# talosCluster.name is the CAPI cluster name AND the namespace it lives in.
+global:
+  namespace: talos-poc
+talosCluster:
+  name: talos-poc
+  kubernetesVersion: v1.32.1
+  controlPlaneMachineCount: 1
+  workerMachineCount: 1
+  podCIDR: 10.243.0.0/16
+  serviceCIDR: 10.95.0.0/16
+  instanceType: o1.xlarge
+  instancePreference: talos
+  rootVolumeSize: 10Gi
+  storageClassName: longhorn
+  talosImageURL: https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.9.5/openstack-amd64.raw.xz
+  talosVersion: v1.9.5
+  talosCode: t195
+  controlPlaneServiceType: NodePort
+  cilium:
+    enabled: true


### PR DESCRIPTION
## What

Make creating / destroying / running several guest clusters on `mocha` a
one-file operation.

Each guest cluster is a **Cluster API** cluster running as **KubeVirt VMs**
(Talos + Cilium). Today they are created imperatively (`clusterctl generate` /
`kubectl apply`), so there is no single, prunable source of truth. This wires
them into Argo CD.

## How it works

- `mocha/bootstrap/as-clusters.yml` — an `ApplicationSet` with a **git files
  generator** over `mocha/clusters/values/*.yaml`. Each file becomes an Argo CD
  `Application` named `cluster-<name>`.
- The generic chart is **reused** from
  [`qjoly/kubevirt-capi-easy`](https://github.com/qjoly/kubevirt-capi-easy)
  (`charts/kubevirt-talos`) through an Argo CD **multi-source** Application
  (chart from that repo + `$values` from this repo). No chart is vendored here;
  only the per-cluster values live in `mocha/clusters/values/`.

Lifecycle:

| Action  | Do this |
|---------|---------|
| Create  | add `mocha/clusters/values/<name>.yaml` + commit |
| Destroy | delete the file + commit (Argo CD prunes → CAPI tears the VMs down) |
| Several | several files (ApplicationSet fan-out) |

`talosCluster.name` is both the cluster name and its namespace. Guest Pod/Service
CIDRs live inside each guest's VMs, so they can be identical across clusters —
no disjoint-CIDR bookkeeping needed.

## First cluster

`mocha/clusters/values/talos-poc.yaml` mirrors the existing `talos-poc`
parameters (NodePort control-plane service, `longhorn`, `o1.xlarge`, Talos
`v1.9.5`, k8s `v1.32.1`).

## Validation

`helm template` against the committed values file renders the full set cleanly
(Cluster, KubevirtCluster, 2× KubevirtMachineTemplate, TalosControlPlane,
TalosConfigTemplate, MachineDeployment, MachineHealthCheck) in namespace
`talos-poc` with the NodePort service and Cilium inline manifest.

## Notes / follow-ups

- **Apply the ApplicationSet** the same way as the sibling `as-app.yml` /
  `as-system.yml` in `mocha/bootstrap/`.
- **Argo CD must reach** `github.com/qjoly/kubevirt-capi-easy` (public) and
  support multi-source (2.6+). Consider pinning the chart `targetRevision` to a
  tag instead of `main` for full determinism.
- **Adopting the live `talos-poc`** (created by hand): review the Argo CD diff
  before enabling sync — the `talosCode` suffix is part of resource names, so a
  mismatch makes CAPI roll new machine templates. Set `talosCode` to match the
  running cluster or recreate it. See `mocha/clusters/README.md`.
- Management-plane prerequisites (CAPI providers, KubeVirt/CDI, `longhorn`, the
  `talos` `VirtualMachineClusterPreference`) are assumed already present on
  `mocha`.