### PR TITLE
feat(mocha): serve did:web:thoughtless.eu document (nginx)

### DIFF
--- a/mocha/apps/thoughtless-did/app.yaml
+++ b/mocha/apps/thoughtless-did/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: thoughtless-did
+  namespace: argocd
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: thoughtless-did
+  source:
+    repoURL: https://github.com/qjoly/gitops.git
+    targetRevision: HEAD
+    path: mocha/apps/thoughtless-did/manifests

--- a/mocha/apps/thoughtless-did/kustomization.yaml
+++ b/mocha/apps/thoughtless-did/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml

--- a/mocha/apps/thoughtless-did/manifests/configmap.yaml
+++ b/mocha/apps/thoughtless-did/manifests/configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thoughtless-did
+data:
+  default.conf: |
+    server {
+        listen 8080 default_server;
+        server_name _;
+
+        location = /.well-known/did.json {
+            default_type application/json;
+            add_header Access-Control-Allow-Origin "*" always;
+            alias /srv/well-known/did.json;
+        }
+
+        location = /.well-known/atproto-did {
+            default_type text/plain;
+            add_header Access-Control-Allow-Origin "*" always;
+            alias /srv/well-known/atproto-did;
+        }
+
+        location = /healthz {
+            default_type text/plain;
+            return 200 "ok\n";
+        }
+
+        location / {
+            return 404;
+        }
+    }
+  # did:web document for did:web:thoughtless.eu. The publicKeyMultibase is the
+  # account's repo signing key -- verify_did_web compares it exactly, so it is
+  # load-bearing and must not be regenerated.
+  did.json: |
+    {
+      "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/multikey/v1",
+        "https://w3id.org/security/suites/secp256k1-2019/v1"
+      ],
+      "id": "did:web:thoughtless.eu",
+      "alsoKnownAs": ["at://thoughtless.eu"],
+      "verificationMethod": [
+        {
+          "id": "did:web:thoughtless.eu#atproto",
+          "type": "Multikey",
+          "controller": "did:web:thoughtless.eu",
+          "publicKeyMultibase": "zQ3shkWnhAT4daQBN1EsQUVU6VGPkfrpuK4zzA6fqSEmobFCU"
+        }
+      ],
+      "service": [
+        {
+          "id": "#atproto_pds",
+          "type": "AtprotoPersonalDataServer",
+          "serviceEndpoint": "https://pds.mocha.thoughtless.eu"
+        }
+      ]
+    }
+  atproto-did: |
+    did:web:thoughtless.eu

--- a/mocha/apps/thoughtless-did/manifests/deployment.yaml
+++ b/mocha/apps/thoughtless-did/manifests/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thoughtless-did
+  labels:
+    app: thoughtless-did
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thoughtless-did
+  template:
+    metadata:
+      labels:
+        app: thoughtless-did
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: web
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+            - name: web
+              mountPath: /srv/well-known/did.json
+              subPath: did.json
+            - name: web
+              mountPath: /srv/well-known/atproto-did
+              subPath: atproto-did
+      volumes:
+        - name: web
+          configMap:
+            name: thoughtless-did

--- a/mocha/apps/thoughtless-did/manifests/ingress.yaml
+++ b/mocha/apps/thoughtless-did/manifests/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thoughtless-did
+  annotations:
+    cert-manager.io/cluster-issuer: cloudflare
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - thoughtless.eu
+      secretName: thoughtless-did-tls
+  rules:
+    - host: thoughtless.eu
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: thoughtless-did
+                port:
+                  number: 80

--- a/mocha/apps/thoughtless-did/manifests/kustomization.yaml
+++ b/mocha/apps/thoughtless-did/manifests/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thoughtless-did
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/mocha/apps/thoughtless-did/manifests/service.yaml
+++ b/mocha/apps/thoughtless-did/manifests/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thoughtless-did
+  labels:
+    app: thoughtless-did
+spec:
+  selector:
+    app: thoughtless-did
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## What

Adds a small static nginx app (`mocha/apps/thoughtless-did`) that serves the AT Protocol identity documents for the apex domain `thoughtless.eu`:

- `GET /.well-known/did.json` — the did:web document for `did:web:thoughtless.eu`
- `GET /.well-known/atproto-did` — returns `did:web:thoughtless.eu` (HTTPS handle-resolution method)

## Why

The PDS account `did:web:thoughtless.eu` (on `pds.mocha.thoughtless.eu`) is an **external did:web** — the PDS does not serve its DID document, the identity owner must. Serving it here:

1. makes the account **verify** (`verify_did_web` checks the service endpoint + signing key), and
2. makes the bare handle **`thoughtless.eu`** resolvable, so the account can switch to it via `updateHandle`.

## Document contents (load-bearing)

- `verificationMethod[0].publicKeyMultibase` is the account's **repo signing key** — the PDS compares it exactly. Do not regenerate.
- `service[0]` = `AtprotoPersonalDataServer` → `https://pds.mocha.thoughtless.eu`
- `alsoKnownAs` = `at://thoughtless.eu`

## Infra

- Standard Ingress `thoughtless.eu` (`ingressClassName: traefik`, `cert-manager.io/cluster-issuer: cloudflare` → DNS-01 apex cert).
- The apex `A thoughtless.eu → 5.196.80.72` record already points at the mocha Traefik LB.
- nginx runs unprivileged (uid 101, port 8080), config + documents mounted from a ConfigMap.

## Validation

- `kubectl kustomize` renders cleanly (app + ConfigMap/Deployment/Service/Ingress).
- `kubectl apply --dry-run=client` passes for all objects.
- `did.json` parses as JSON and matches the exact shape `verify_did_web` expects.