### PR TITLE
fix(mocha): pin tranquil-pds to a frontend-enabled image digest

### DIFF
--- a/mocha/apps/tranquil-pds/app.yaml
+++ b/mocha/apps/tranquil-pds/app.yaml
@@ -35,7 +35,10 @@ spec:
     targetRevision: 0.1.0
     helm:
       values: |
-        imagePullPolicy: Always
+        # Pinned to a digest that ships the built-in frontend (/app UI).
+        # The :latest tag drifted to a build without the `frontend` feature.
+        image: atcr.io/tranquil.farm/tranquil-pds@sha256:9d803e048be9231ddc5dde854b9f581bf40a614adb6c812ac497bc7b8d4c06ce
+        imagePullPolicy: IfNotPresent
         storageClass: openebs-lvmpv
         ingress:
           host: pds.mocha.thoughtless.eu


### PR DESCRIPTION
## Problem

The built-in web UI at `https://pds.mocha.thoughtless.eu/app` returned `Cannot GET /app` and the root `/` served the plain-text ASCII banner instead of the homepage.

Root cause: the deployment used `image: :latest` with `imagePullPolicy: Always`. The `:latest` tag drifted to a build compiled **without** the `frontend` cargo feature (`sha256:5a8fea8f…`). In `tranquil-pds`, the `/`, `/app`, and `/oauth-client-metadata.json` routes are gated behind `cfg!(feature = "frontend")`, so they were never registered — even though the frontend files ship in the image. The `postgres` feature stayed enabled, so the database kept working, which masked the regression. The pod re-pulled the drifted `:latest` on its restart after an unrelated sync.

## Fix

Pin the image to a digest that ships the frontend and stop chasing `:latest`:

- `image: atcr.io/tranquil.farm/tranquil-pds@sha256:9d803e04…4c06ce` — this is commit `26aa399`, whose `tranquil-server` crate has `default = ["bsky", "frontend", "postgres", "s3", "valkey"]`, so `/app` is served (verified from source).
- `imagePullPolicy: IfNotPresent` — deterministic, no more silent drift.

## Safety

- The live DB is at migration `20260721`, which is exactly the latest migration present in this image — **no schema downgrade**, the rollback is safe.
- `helm template` (published chart `tranquil-pds` 0.1.0 + mocha values) renders the Deployment with the pinned digest and `IfNotPresent`; all 9 objects intact, postgres unchanged.
- `kubectl kustomize` renders a valid ArgoCD Application.

## Follow-up (not in this PR)

`:latest` should be re-pinned to a proper semver tag (e.g. `0.6.0`) once it is confirmed to still bundle the frontend.