### PR TITLE
fix(mocha): point thoughtless-did did.json to handle 192168128.xyz

### DIFF
--- a/mocha/apps/thoughtless-did/manifests/configmap.yaml
+++ b/mocha/apps/thoughtless-did/manifests/configmap.yaml
@@ -40,7 +40,7 @@ data:
         "https://w3id.org/security/suites/secp256k1-2019/v1"
       ],
       "id": "did:web:thoughtless.eu",
-      "alsoKnownAs": ["at://thoughtless.eu"],
+      "alsoKnownAs": ["at://192168128.xyz"],
       "verificationMethod": [
         {
           "id": "did:web:thoughtless.eu#atproto",


### PR DESCRIPTION
## What

Update the statically-served `did:web` document at `https://thoughtless.eu/.well-known/did.json` so its `alsoKnownAs` matches the account's current handle:

```diff
-  "alsoKnownAs": ["at://thoughtless.eu"],
+  "alsoKnownAs": ["at://192168128.xyz"],
```

## Why

The account handle was changed to `192168128.xyz` (via `com.atproto.identity.updateHandle`), but the `did:web:thoughtless.eu` document served at the apex still declared `at://thoughtless.eu`. For a `did:web` account the apex document is authoritative for the whole network, so the stale `alsoKnownAs` broke bidirectional handle verification for the new handle (AppView returned *profile not found* for `192168128.xyz`).

DNS `_atproto.192168128.xyz` TXT already resolves to `did:web:thoughtless.eu`; this change makes the DID document point back, satisfying the bidirectional check.

## Scope

Single-line change. The signing key (`publicKeyMultibase`), `serviceEndpoint` (`https://pds.mocha.thoughtless.eu`) and the `atproto-did` (the DID itself) are unchanged.

## Validation

- `kubectl kustomize` renders ConfigMap/Service/Deployment/Ingress cleanly.
- Embedded `did.json` is valid JSON; `alsoKnownAs = ["at://192168128.xyz"]`, other fields intact.
- Live apex already serves the corrected value (patched by hand); this PR persists it so ArgoCD self-heal no longer reverts it on the next nginx restart.