### PR TITLE
chore(mocha): bump tranquil-pds to chart 0.2.0 and set crawler relays

### DIFF
--- a/mocha/apps/tranquil-pds/app.yaml
+++ b/mocha/apps/tranquil-pds/app.yaml
@@ -32,7 +32,7 @@ spec:
   source:
     repoURL: https://rubxkube.github.io/charts
     chart: tranquil-pds
-    targetRevision: 0.1.0
+    targetRevision: 0.2.0
     helm:
       values: |
         # Pinned to a digest that ships the built-in frontend (/app UI).
@@ -47,3 +47,12 @@ spec:
         sso:
           issuer: https://authentik.mocha.thoughtless.eu/application/o/tranquil-pds/
           displayName: Authentik
+        # Default relay list minus relay.fire.hose.cam (dead host, spams requestCrawl WARNs).
+        crawlers:
+          - https://relay3.fr.hose.cam
+          - https://bsky.network
+          - https://northamerica.firehose.network
+          - https://europe.firehose.network
+          - https://asia.firehose.network
+          - https://atproto.africa
+          - https://relay.upcloud.world


### PR DESCRIPTION
## Summary
Consume the `tranquil-pds` Helm chart `0.2.0` (which adds the `crawlers` passthrough) and pin an explicit relay list for the PDS.

## Why
The default relay list baked into tranquil-pds starts with `https://relay.fire.hose.cam`, a **dead host** that fails on every `requestCrawl` at startup and spams WARN logs. This overrides the list with the **upstream defaults minus that dead relay**, keeping `https://bsky.network` so the PDS keeps federating with the public Bluesky relay.

## Changes
- `mocha/apps/tranquil-pds/app.yaml`:
  - `targetRevision: 0.1.0` → `0.2.0`
  - add `crawlers:` (7 relays = upstream defaults without `relay.fire.hose.cam`)

## Validation
- Chart `tranquil-pds-0.2.0` is published (`rubxkube.github.io/charts`).
- `helm template` of the published 0.2.0 chart with these values renders `CRAWLERS` as the expected comma-joined list.
- `kubectl kustomize` renders the ArgoCD Application with `targetRevision: 0.2.0` and the crawler values.