### PR TITLE
fix(mocha): raise CrowdSec LAPI CPU limit to stop fail-closed 403s

### DIFF
--- a/mocha/system/crowdsec/app.yaml
+++ b/mocha/system/crowdsec/app.yaml
@@ -42,6 +42,13 @@ spec:
               serviceMonitor:
                 enabled: true
           lapi:
+            resources:
+              requests:
+                cpu: 500m
+                memory: 500Mi
+              limits:
+                cpu: "2"
+                memory: 512Mi
             env:
               - name: BOUNCER_KEY_traefik
                 valueFrom:


### PR DESCRIPTION
## Problem

Intermittent `403` responses across **all** mocha services behind Traefik — including unauthenticated endpoints (e.g. `/xrpc/_health`) — with an empty body. This is the Traefik CrowdSec bouncer **failing closed**, not the backend apps.

## Root cause (measured)

The bouncer runs in `stream` mode and is applied **globally** on the `websecure` entrypoint. It periodically refreshes decisions from the LAPI `/v1/decisions/stream` endpoint, which serves ~700KB of CAPI community-blocklist entries.

The LAPI ran with the chart default CPU limit of **500m** and was CPU-throttled while serializing that stream:

| Measurement | Value |
|---|---|
| `/v1/decisions/stream` response time (LAPI @ 500m) | **12–25s** for ~700KB |
| Bouncer plugin stream timeout | ~10s |
| LAPI `/health` | instant (masked the issue) |
| LAPI pod restarts | 0 (pure CPU throttle, not OOM) |

On timeout the plugin marks the stream unhealthy (`isCrowdsecStreamHealthy:false`) and **fails closed → 403 on every websecure request**. Because the stream sometimes squeaks under the timeout, the failure is intermittent.

Verified that the bouncer is the culprit by hitting the PDS both ways:

| Path | `/xrpc/_health` (no auth) |
|---|---|
| Service ClusterIP (bypass Traefik) | **200** |
| Public hostname (through Traefik/CrowdSec) | **403** (40/40 in a burst) |

## Fix

Override `lapi.resources` to raise the CPU **limit** to 2 cores (request kept at 500m for burst headroom, memory at 512Mi). This lets the stream serialize well under the plugin timeout, so the bouncer stays healthy.

```diff
           lapi:
+            resources:
+              requests:
+                cpu: 500m
+                memory: 500Mi
+              limits:
+                cpu: "2"
+                memory: 512Mi
```

## Validation

- `kubectl kustomize mocha/system/crowdsec` renders cleanly; embedded Helm values carry `lapi.resources.limits.cpu: "2"`.
- Chart pin unchanged (`crowdsec 0.24.0`); only the LAPI resources are overridden.

## Blast radius

CrowdSec is the shared security edge for the whole cluster (`selfHeal: true`). This change only raises the LAPI CPU ceiling — no policy/scenario changes.