### PR TITLE
fix(mocha): enable sqlite WAL on crowdsec LAPI to fix fail-closed 403s

### DIFF
--- a/mocha/system/crowdsec/app.yaml
+++ b/mocha/system/crowdsec/app.yaml
@@ -42,19 +42,14 @@ spec:
               serviceMonitor:
                 enabled: true
           lapi:
-            resources:
-              requests:
-                cpu: 500m
-                memory: 500Mi
-              limits:
-                cpu: "2"
-                memory: 512Mi
             env:
               - name: BOUNCER_KEY_traefik
                 valueFrom:
                   secretKeyRef:
                     name: crowdsec-bouncer
                     key: key
+              - name: USE_WAL
+                value: "true"
             persistentVolume:
               data:
                 enabled: true


### PR DESCRIPTION
## Problem

Intermittent `403` on **all** `websecure` traffic in mocha (every service, not just tranquil-pds). The Traefik CrowdSec bouncer runs in `stream` mode and **fails closed** whenever its periodic `/v1/decisions/stream` refresh times out:

```
WARN  handleStreamTicker ... crowdsecQuery:unreachable /v1/decisions/stream
      context deadline exceeded (Client.Timeout exceeded while awaiting headers)
WARN  updateFailure ... isCrowdsecStreamHealthy:false   -> 403 on everything
```

## Root cause (measured, not guessed)

The LAPI sqlite DB ran in **rollback-journal mode** (a `crowdsec.db-journal` file was present). In that mode sqlite takes an **exclusive lock**, so the decision-stream read blocked on the lock held by heartbeat / bouncer-key writes:

```
error  heartbeat error: ... database is locked: unable to update
warn   QueryExpiredDecisionsWithFilters : context canceled
```

The ~720KB decision stream then took **12-25s to send headers** > the plugin's ~10s timeout -> fail closed. The LAPI is **CPU-idle (~3m)** and the DB is only ~18MB / ~5300 decisions, so it was never a CPU or volume problem — it was **sqlite lock contention**.

## Fix

Set `USE_WAL=true` on the LAPI. In WAL mode readers no longer block on the writer, so the stream returns fast and the plugin stays healthy.

**Verified live** after enabling WAL:
- `crowdsec.db-journal` -> `crowdsec.db-wal` (+`-shm`), no more `database is locked`
- `/v1/decisions/stream` via the bouncer's ClusterIP path: **12-25s -> ~10ms**
- edge stable: **100/100 concurrent requests to a no-auth endpoint -> 200** (was 40/40 -> 403)

## Also

Drops the LAPI CPU-limit bump from #485 — that was a **misdiagnosis** (the LAPI is CPU-idle, the bump had no effect). Reverts `lapi.resources` to chart defaults.

Blast radius: the CrowdSec bouncer is a **global** middleware on all mocha `websecure` routes, so this restores the whole cluster edge, not just the PDS.