### PR TITLE
chore(vaultwarden): upgrade to 1.37.2 for 2026.8.0+ client support

### DIFF
--- a/mocha/apps/vaultwarden/app.yaml
+++ b/mocha/apps/vaultwarden/app.yaml
@@ -22,7 +22,7 @@ spec:
               name: "vaultwarden"
               image:
                 repository: vaultwarden/server
-                tag: "1.37.0"
+                tag: "1.37.2"
               service:
                 servicePort: 80
                 containerPort: 80


### PR DESCRIPTION
## Problem

Bitwarden browser/desktop clients keep getting logged out of Vaultwarden. Root cause: the deployed server (`1.37.0`) is not compatible with the current Bitwarden clients (`2026.8.0+`). On token refresh, an outdated server returns `401` without the `invalid_grant` error code the client expects, so the client rejects the refresh token and drops the session instead of renewing it.

Refs: [vaultwarden#7060](https://github.com/dani-garcia/vaultwarden/issues/7060), [discussion#6848](https://github.com/dani-garcia/vaultwarden/discussions/6848), [discussion#7658](https://github.com/dani-garcia/vaultwarden/discussions/7658).

## Change

- `mocha/apps/vaultwarden/app.yaml`: bump `image.tag` `1.37.0` -> `1.37.2` (latest stable, released 2026-08-22).

The upstream 1.37.2 release note states: *"This update is required for support with clients with version 2026.8.0+."*

## Notes

- No chart change needed; the `common` v0.6.0 chart just forwards `image.tag`.
- ArgoCD auto-sync + selfHeal will roll the deployment once merged.