### PR TITLE
fix(bank-vaults): relax vault liveness/readiness probe timeouts

### DIFF
--- a/mocha/system/bank-vaults/vault/vault.yaml
+++ b/mocha/system/bank-vaults/vault/vault.yaml
@@ -18,6 +18,25 @@ spec:
     name: vault
     args:
       - "-config=/vault/config"
+    # Relaxed from the operator default (timeoutSeconds 1) to survive transient
+    # slowness of /v1/sys/health under node contention and avoid liveness crashloops.
+    livenessProbe:
+      httpGet:
+        path: /v1/sys/health?standbyok=true
+        port: 8200
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 5
+    readinessProbe:
+      httpGet:
+        path: /v1/sys/health?standbyok=true&perfstandbyok=true&drsecondarycode=299
+        port: 8200
+        scheme: HTTPS
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 3
 
   securityContext:
     runAsUser: 100


### PR DESCRIPTION
## Problem

The bank-vaults `Vault` CR does not declare probes, so the operator generates a
default liveness probe with `timeoutSeconds: 1`. On mocha, `/v1/sys/health`
periodically takes longer than 1s under node contention (everything runs on a
single node, ClickHouse/SigNoz alone eats ~2.9 cores). The kubelet then kills
and restarts `vault-0` in a loop — **~430 restarts observed**, roughly one kill
every 16 min (`Liveness probe failed: context deadline exceeded`, graceful
`exit 0`, no OOM).

### Blast radius

Each restart flaps the vault `EndpointSlices`, which repeatedly re-triggers
Traefik dynamic-config processing. The CrowdSec bouncer plugin (stream mode)
re-initialises with an **empty cache** on each reload and **fails closed
(HTTP 403)** while it re-pulls the decision stream (`stream?startup=true`).
Result: intermittent **403 bursts on Authentik** and other apps behind
`websecure`. (An orphaned `kromgo` Ingress in `monitoring` was flooding the
same config-reload path and has already been removed live.)

## Change

Declare explicit `livenessProbe` / `readinessProbe` on `vaultContainerSpec`:

- `timeoutSeconds` 1 → **5**
- liveness `failureThreshold` 3 → **5**
- `initialDelaySeconds` **30**

This matches the config already applied live on mocha, which cut restarts from
**~430 to 2 over 95 min**.

## Notes

- The live change was applied by patching the CR directly; ArgoCD (`ServerSideApply=true`,
  `selfHeal: true`) left the fields untouched because git did not declare them.
  This PR makes the fix declared and durable in GitOps.
- Honest caveat: 5s **reduced but did not fully eliminate** the liveness kills —
  `/v1/sys/health` still occasionally exceeds 5s (residual single-node latency
  on OpenBao). A follow-up may need a larger timeout / higher `failureThreshold`,
  or moving vault off the contended node.