### PR TITLE
fix(signoz): mitigate ClickHouse read-only flapping from ZooKeeper disk contention

### DIFF
--- a/mocha/system/signoz/signoz.yaml
+++ b/mocha/system/signoz/signoz.yaml
@@ -35,6 +35,18 @@ spec:
           # Keep "move to cold storage" off for metrics in the SigNoz retention
           # settings (it lives in SigNoz's own DB, not here). Only signals with few,
           # large parts belong on this volume.
+          #
+          # 2026-09-04: the same failure recurred on the LOGS side. logs_v2 moved parts
+          # to cold storage after only 1 day (_retention_days_cold=1) while still holding
+          # thousands of tiny parts, freezing them on S3 and pushing the daily partition
+          # toward the 3000-part limit. The deeper root cause: ZooKeeper and ClickHouse
+          # share this single-node openebs-lvmpv disk, and ClickHouse merge I/O starves
+          # ZK's WAL fsync (observed 2-61s), expiring ClickHouse's ZK session (30s
+          # default) so every replicated table drops to read-only, merges stop committing
+          # and parts pile up. Mitigated below by larger collector batches (less churn)
+          # and a longer ZK session timeout. The logs move-to-cold is pushed out in the
+          # SigNoz retention settings, same as metrics. A dedicated/faster disk for
+          # ZooKeeper is the real structural fix.
           coldStorage:
             enabled: true
             type: s3
@@ -49,6 +61,18 @@ spec:
               memory: 8Gi
             limits:
               memory: 24Gi
+          # Raise ClickHouse's ZooKeeper client session/operation timeouts above the
+          # 30s/10s defaults so a replica rides out multi-second ZK WAL fsync stalls
+          # instead of dropping to read-only. This merges into the operator-generated
+          # <zookeeper> config and does not touch the node list.
+          files:
+            config.d/zookeeper-timeouts.xml: |
+              <clickhouse>
+                <zookeeper>
+                  <session_timeout_ms>60000</session_timeout_ms>
+                  <operation_timeout_ms>20000</operation_timeout_ms>
+                </zookeeper>
+              </clickhouse>
         signoz:
           ingress:
             enabled: true
@@ -65,3 +89,13 @@ spec:
               - secretName: signoz-tls
                 hosts:
                   - signoz.mocha.thoughtless.eu
+        otelCollector:
+          # The chart default flushes a batch to ClickHouse every 1s (batch.timeout),
+          # which at low log volume produces thousands of ~40KiB parts per day. ClickHouse
+          # then burns disk I/O merging them, starving ZooKeeper's fsync (see the
+          # clickhouse comment above). Batching for 30s yields far fewer, larger parts and
+          # far fewer merges. send_batch_size (50000) is inherited from the chart default.
+          config:
+            processors:
+              batch:
+                timeout: 30s


### PR DESCRIPTION
## Problem

Access to Authentik (and other apps) was flapping. Root cause traced through several layers down to **SigNoz's ClickHouse going read-only in a loop**:

- ClickHouse and ZooKeeper share the **single-node `openebs-lvmpv` disk** on `talos-4e6-sx1`.
- Under ClickHouse merge I/O, ZooKeeper's WAL `fsync` stalls for seconds — **observed 2s up to 61s** in the ZK logs.
- A stall longer than the ClickHouse ZK **session timeout (30s default)** expires the session → **every ReplicatedMergeTree table drops to read-only** → merges can't commit → parts accumulate toward `parts_to_throw_insert` (3000) → inserts get rejected.
- `_retention_days_cold=1` on `logs_v2` made it worse: parts were frozen on S3 cold storage (`prefer_not_to_merge=1`) after 1 day while still thousands of tiny (~40KiB) parts — the logs-side recurrence of the 2026-08-08 metrics incident.

## Changes (config-only, GitOps)

- **`otelCollector.config.processors.batch.timeout` 1s → 30s.** The chart default flushes a batch to ClickHouse every second; at low log volume that produces thousands of ~40KiB parts/day, and the resulting merge I/O is what starves ZK's fsync. Larger batches ⇒ far fewer, larger parts ⇒ far fewer merges. `send_batch_size` (50000) is inherited from the chart default (verified via `helm template`).
- **ClickHouse ZK client `session_timeout_ms` 30s → 60s, `operation_timeout_ms` 10s → 20s** via a `clickhouse.files` config.d drop-in, so a replica rides out multi-second fsync stalls instead of going read-only. Merges into the operator-generated `<zookeeper>` block without touching the node list.
- Extends the existing cold-storage comment to document the logs-side recurrence and the real root cause.

## Validation

- Outer + inner (`helm.values`) YAML parse clean.
- `helm template signoz/signoz --version 0.139.0` with these values confirms the deep-merge: rendered `batch` keeps `send_batch_size: 50000` and gets `timeout: 30s`; the CHI renders `config.d/zookeeper-timeouts.xml` with `session_timeout_ms=60000`.
- Live: `SYSTEM STOP MERGES` was used to break the acute loop; ZK fsync recovered 61s → ~2s and `logs_v2` came out of read-only. This PR is the durable, config-level fix. Syncing it rolls the ClickHouse pod, which also clears any residual read-only state.

## Not in this PR

- **Logs move-to-cold retention** (`_retention_days_cold 1 → 15`): this is **not a Helm value** — it lives in SigNoz's own retention settings (same as the metrics fix). To be applied in the SigNoz UI / retention API.
- **Structural fix**: give ZooKeeper a dedicated/faster disk (separate from ClickHouse) or move it off the contended node. That is the only thing that removes the fsync contention entirely; the two mitigations here reduce its frequency and blast radius.