### PR TITLE
fix(crowdsec): move LAPI sqlite DB to tmpfs to stop bouncer fail-close 403s

### DIFF
--- a/mocha/system/crowdsec/app.yaml
+++ b/mocha/system/crowdsec/app.yaml
@@ -51,14 +51,21 @@ spec:
               - name: USE_WAL
                 value: "true"
             persistentVolume:
+              # DB on tmpfs (extraVolumes below) to escape openebs-lvmpv I/O contention; data is regenerable.
               data:
-                enabled: true
-                storageClassName: openebs-lvmpv
-                size: 1Gi
+                enabled: false
               config:
                 enabled: true
                 storageClassName: openebs-lvmpv
                 size: 100Mi
+            extraVolumes:
+              - name: crowdsec-db
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 128Mi
+            extraVolumeMounts:
+              - name: crowdsec-db
+                mountPath: /var/lib/crowdsec/data
             metrics:
               serviceMonitor:
                 enabled: true


### PR DESCRIPTION
## Symptom

Clients hitting public hosts behind Traefik (e.g. `vaultwarden.mocha.thoughtless.eu`) intermittently get **HTTP 403 with an empty body** — no `server` header, just `Date` + `Content-Length: 0`. Seen from the Bitwarden iOS app on `/identity/sso/prevalidate`. Not Vaultwarden-specific: the CrowdSec bouncer middleware is applied **globally on websecure**, so any public host can 403.

## Diagnosis (with direct evidence)

The bouncer runs in `stream` mode and periodically refreshes decisions from the LAPI. During the incident window the LAPI could not serve the stream:

```
07:18:30  /v1/decisions/stream  200  2m25s     <- 2m25s to serve the stream
07:18:30  /v1/decisions/stream  403  1m25s   (context canceled)
07:19:06  /v1/decisions/stream  200  840ms      <- recovery
07:26:42  "error while deleting orphan events: database is locked"
```

The client 403 at `07:19:05` falls exactly inside the `07:18:30 -> 07:19:06` gap. When the bouncer cannot refresh, the plugin **fails closed -> 403 on every host on websecure**. Outside the window, `prevalidate` returns `200` end-to-end (verified live via the ClusterIP and via the public LB). No active CrowdSec decisions, no IP allowlist, DNS is a direct A record (no Cloudflare proxy) — so this is not a ban, not the SSO config, not the backend.

## Root cause

`mocha` is single-node. The LAPI sqlite DB (`crowdsec-db-pvc`) lives on `openebs-lvmpv`, the **same local disk** as signoz ZooKeeper + ClickHouse. Under their I/O storms (ZK fsync 2-16s) the DB write path starves: the ~3MB / ~23k-decision CAPI stream that takes <1s at rest climbs to `2m25s` + `database is locked`, the plugin times out, and the bouncer fails closed.

WAL mode (a previous mitigation, `USE_WAL=true`) is no longer sufficient.

## Fix

Move the LAPI DB volume to an in-memory `emptyDir` (`medium: Memory`) so it never touches the contended disk. This is safe because the DB is fully regenerable:

- CAPI community blocklist is re-pulled on boot.
- The Traefik bouncer key is re-registered on every boot from `BOUNCER_KEY_traefik` (env).
- Identity/creds (`online_api_credentials.yaml`, `local_api_credentials.yaml`) live on the **config PVC**, which is untouched.

Verified with `helm template` (chart 0.24.0): the rendered LAPI Deployment mounts the `emptyDir{medium: Memory}` at `/var/lib/crowdsec/data` and the `crowdsec-db-pvc` is no longer created. Memory footprint is tiny (DB ~28MB; pod uses ~31Mi of a 500Mi limit).

## Notes for review

- **Orphan PVC**: `automated.prune` is off, so the existing `crowdsec-db-pvc` (1Gi) is left behind after sync — delete it manually once healthy.
- **Rollout churn**: the config PVC is still RWO on `openebs-lvmpv`, so the switch-over rollout will briefly `FailedMount` (surge vs RWO) for ~90s and cause one short LAPI gap. A follow-up `lapi.strategy: Recreate` would make future rollouts clean; kept out of this PR to stay focused.