### PR TITLE
fix(crowdsec): fully disable CrowdSec to stop bouncer 403s

### DIFF
--- a/mocha/system/crowdsec/app.yaml
+++ b/mocha/system/crowdsec/app.yaml
@@ -12,6 +12,7 @@ spec:
         pod-security.kubernetes.io/audit: privileged
         pod-security.kubernetes.io/warn: privileged
     automated:
+      prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
@@ -26,6 +27,7 @@ spec:
         values: |
           container_runtime: containerd
           agent:
+            enabled: false
             acquisition:
               - namespace: traefik
                 podName: traefik-*
@@ -42,6 +44,11 @@ spec:
               serviceMonitor:
                 enabled: true
           lapi:
+            enabled: false
+            # Placeholders required by the chart's external-LAPI validation; unused while disabled.
+            secrets:
+              csLapiSecret: "disabled"
+              registrationToken: "disabled"
             env:
               - name: BOUNCER_KEY_traefik
                 valueFrom:

--- a/mocha/system/traefik/app.yaml
+++ b/mocha/system/traefik/app.yaml
@@ -23,23 +23,6 @@ spec:
         accessLog:
           enabled: true
           format: json
-        experimental:
-          plugins:
-            bouncer:
-              moduleName: github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
-              version: v1.6.0
-        additionalArguments:
-          - "--entrypoints.websecure.http.middlewares=traefik-crowdsec-bouncer@kubernetescrd"
-        deployment:
-          additionalVolumes:
-            - name: crowdsec-bouncer-key
-              secret:
-                secretName: crowdsec-bouncer
-                optional: true
-        additionalVolumeMounts:
-          - name: crowdsec-bouncer-key
-            mountPath: /etc/traefik/crowdsec
-            readOnly: true
         metrics:
           prometheus: null
           otlp:


### PR DESCRIPTION
## Why
The global Traefik CrowdSec bouncer middleware on the `websecure` entrypoint **fail-closes** whenever the LAPI can't refresh its decisions, returning empty-body **403s across every public host** — repeatedly breaking Vaultwarden/Bitwarden SSO. Disabling CrowdSec entirely, as requested.

## What
**`mocha/system/traefik/app.yaml`** — take CrowdSec out of the request path:
- remove the `experimental.plugins.bouncer` plugin
- remove the global `--entrypoints.websecure.http.middlewares=traefik-crowdsec-bouncer@kubernetescrd` arg
- remove the `crowdsec-bouncer-key` volume/mount

**`mocha/system/crowdsec/app.yaml`** — stop the workloads:
- `agent.enabled=false`, `lapi.enabled=false` (with placeholder external-LAPI secrets the chart validation requires)
- `prune=true` so ArgoCD removes the LAPI Deployment, agent DaemonSet, services and PVCs

## Validation (offline, `helm template`)
- Traefik renders with **no crowdsec/bouncer** references; Deployment intact.
- crowdsec renders to **only a ConfigMap + Secret** — zero workloads.
- No Ingress/IngressRoute references the middleware directly, so removal is safe.

## Notes
- Merge triggers a brief Traefik restart (~15-30s edge blip, replicas=1).
- The inert Middleware CR + ExternalSecrets in `manifests/` are left in place (harmless); can be removed in a follow-up.
- CrowdSec config (tmpfs/WAL/acquisition) is kept but inert, so re-enabling later is a one-line flip.