### PR TITLE
fix(authentik): relax server probes to survive single-node I/O stalls

### DIFF
--- a/mocha/system/authentik/authentik.yaml
+++ b/mocha/system/authentik/authentik.yaml
@@ -60,6 +60,15 @@ spec:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+            # Single-node openebs-lvmpv I/O stalls freeze authentik for tens of
+            # seconds; default probes (3s timeout, 3 failures = ~30s) SIGKILL it
+            # mid-stall and take OIDC discovery down. Relax to ride out stalls.
+            livenessProbe:
+              timeoutSeconds: 10
+              failureThreshold: 6
+            readinessProbe:
+              timeoutSeconds: 10
+              failureThreshold: 6
             ingress:
               enabled: true
               ingressClassName: traefik


### PR DESCRIPTION
## Problem

Vaultwarden SSO logins intermittently fail with `Failed to discover OpenID provider: Request failed`. Root cause is the authentik-server pod going unreachable: openebs-lvmpv I/O contention on the single node (signoz ClickHouse/ZooKeeper) freezes authentik for tens of seconds.

The default server probes are too tight for that:
- **liveness**: `timeoutSeconds: 3`, `failureThreshold: 3`, `periodSeconds: 10` → ~30s of stall → **SIGKILL (exit 137)** and restart. Observed in logs: a 33s gap in health checks at 10:37 UTC followed by `signal TERM received` → exit 137, 3 restarts total.
- **readiness**: same tightness → the single replica gets pulled from the Service during a stall, so discovery fails even without a restart.

Both take OIDC discovery down exactly when a client hits it.

## Change

Relax the **server** liveness and readiness probes (deep-merged over chart defaults, `httpGet`/`periodSeconds` preserved):

| field | before | after |
|---|---|---|
| `timeoutSeconds` | 3 | 10 |
| `failureThreshold` | 3 | 6 |

New tolerance: ~60s of consecutive failures before SIGKILL, each probe tolerating a 10s slow response. A transient I/O stall no longer kills or de-registers the pod. startupProbe is untouched.

## Validation

- `helm template` (chart 2026.8.0) confirms the rendered server Deployment has `failureThreshold: 6` / `timeoutSeconds: 10` on both probes, with `httpGet` paths and `periodSeconds: 10` preserved from defaults.

## Notes

This is a mitigation, not the root fix — the underlying single-node openebs-lvmpv I/O contention (signoz) is the real cause and remains to be addressed. Blast radius is low: worst case a genuinely-hung pod takes ~60s instead of ~30s to restart.