### PR TITLE
fix(vault): relax bank-vaults probes to survive single-node I/O stalls

### DIFF
--- a/mocha/system/bank-vaults/vault/vault.yaml
+++ b/mocha/system/bank-vaults/vault/vault.yaml
@@ -18,6 +18,28 @@ spec:
     name: vault
     args:
       - "-config=/vault/config"
+    # Single-node Raft on openebs-lvmpv: I/O stalls (signoz ClickHouse/ZK) freeze the
+    # API for up to ~2m25s. Killing on liveness only makes it worse (restart -> reseal
+    # -> more I/O). Tolerate ~180s before restart; readiness steers traffic non-destructively.
+    livenessProbe:
+      httpGet:
+        path: /v1/sys/health?standbyok=true
+        port: 8200
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 10
+      failureThreshold: 12
+      successThreshold: 1
+    readinessProbe:
+      httpGet:
+        path: /v1/sys/health?standbyok=true&perfstandbyok=true&drsecondarycode=299
+        port: 8200
+        scheme: HTTPS
+      periodSeconds: 5
+      timeoutSeconds: 10
+      failureThreshold: 6
+      successThreshold: 1
 
   securityContext:
     runAsUser: 100


### PR DESCRIPTION
## Problem
`bank-vaults/vault-0` (OpenBao, Raft on `openebs-lvmpv`) was **liveness-killed 358 times over 3 days**. The single node `talos-4e6-sx1` is I/O-starved by signoz ClickHouse/ZooKeeper, so the Vault API freezes for **up to ~2m25s** during storms.

The live probes (`timeoutSeconds 5` × `failureThreshold 5` ≈ 50s) were a **manual drift not present in git** (surviving via `ServerSideApply`, hence the app's `OutOfSync`) and too tight: every stall killed the pod → reseal → re-unseal → **more I/O**, breaking ExternalSecrets cluster-wide (cert/DNS renewals).

## Change
Declare the probes explicitly in `vault.yaml` (also resolves the OutOfSync drift) and relax them for a **single-node** store where killing is counter-productive:

| probe | field | before (live drift) | after |
|---|---|---|---|
| liveness | timeout / period / threshold | 5 / 10 / 5 (~50s) | **10 / 15 / 12 (~180s)** |
| readiness | timeout / period / threshold | 5 / 5 / 3 | **10 / 5 / 6 (~30s)** |

- **Liveness** now tolerates ~180s (> observed 2m25s worst case) → only restarts a genuinely wedged process.
- **Readiness** steers traffic away non-destructively during a stall.

## Validation
- `kubectl kustomize` renders cleanly; server-side dry-run accepts the CR against the live CRD.

Mitigation only — the root cause remains node I/O contention from signoz.