### PR TITLE
chore(signoz): park stack (scale to 0) to spare worn-out node SSD

### DIFF
--- a/mocha/system/signoz/signoz.yaml
+++ b/mocha/system/signoz/signoz.yaml
@@ -22,6 +22,15 @@ spec:
         global:
           storageClass: openebs-lvmpv
         clickhouse:
+          # PARK 2026-09-08: nvme1n1 (openebs-lvmpv) is worn out (SMART 106% used,
+          # critical_warning 0x8 read-only mode, ~48s write latency). SigNoz's
+          # ClickHouse+ZooKeeper are the dominant writers wearing the disk, so scale
+          # the whole stack to 0 until the SSD is replaced. Re-enable by restoring
+          # these counts to 1. PVCs are retained (no prune + operator default Retain).
+          layout:
+            replicasCount: 0
+          zookeeper:
+            replicaCount: 0
           persistence:
             enabled: true
             size: 100Gi
@@ -74,6 +83,7 @@ spec:
                 </zookeeper>
               </clickhouse>
         signoz:
+          replicaCount: 0
           ingress:
             enabled: true
             className: traefik
@@ -90,6 +100,7 @@ spec:
                 hosts:
                   - signoz.mocha.thoughtless.eu
         otelCollector:
+          replicaCount: 0
           # The chart default flushes a batch to ClickHouse every 1s (batch.timeout),
           # which at low log volume produces thousands of ~40KiB parts per day. ClickHouse
           # then burns disk I/O merging them, starving ZooKeeper's fsync (see the


### PR DESCRIPTION
## Why
`nvme1n1` (the openebs-lvmpv disk on the single node `talos-4e6-sx1`) has exceeded its write endurance:
- SMART `percentage_used` = **106%**
- `critical_warning` = **0x8** (media switched to read-only mode)
- measured **~48s** write latency (await), PSI I/O full ≈ 55%

SigNoz's ClickHouse + ZooKeeper are the dominant writers on that disk and are the root cause behind the cascade of incidents (CrowdSec 403 fail-close, Vault crashloop, Authentik SIGKILL). Park the whole SigNoz stack until the SSD is replaced.

## What
Scale every SigNoz workload to 0, keeping resources rendered (selfHeal is on, prune is off):
- `clickhouse.layout.replicasCount: 0` → operator scales the ClickHouse host StatefulSet to 0
- `clickhouse.zookeeper.replicaCount: 0`
- `signoz.replicaCount: 0`
- `otelCollector.replicaCount: 0`
- ClickHouse operator stays at 1 (needed to reconcile the CHI and to re-enable later)

PVCs are **retained** (no prune + Altinity operator default Retain). Reverting = restore the counts to 1.

## Validation
`helm template signoz/signoz 0.139.0` with these values renders cleanly (exit 0): CHI `layout.replicasCount=0`, and the zookeeper/signoz/otel-collector workloads at `replicas: 0`.